### PR TITLE
chore: use PROJECT_SOURCE instead of PROJECTS_ROOT

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -2,10 +2,9 @@ schemaVersion: 2.1.0
 metadata:
   name: java-lombok
 components:
-
   - name: tools
     container:
-      image: quay.io/devfile/universal-developer-image:ubi8-latest
+      image: quay.io/devfile/universal-developer-image:ubi8-0e189d9
       memoryLimit: 3Gi
       endpoints:
         - exposure: none
@@ -21,10 +20,10 @@ components:
       size: 1G
   
 commands:
-  - id: build
+  - id: maven-build
     exec:
       component: tools
-      workingDir: ${PROJECTS_ROOT}/lombok-project-sample
+      workingDir: ${PROJECT_SOURCE}
       commandLine: mvn clean install
       group:
         kind: build


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

- Replaces PROJECTS_ROOT environment variable on PROJECT_SOURCE in devfile commands
- Bumps to the latest tag of universal developer image
