### PR TITLE
chore: add missing vscjava.vscode-java-debug and vscjava.vscode-java-test extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,8 @@
     // See https://go.microsoft.com/fwlink/?LinkId=827846
     // for the documentation about the extensions.json format
     "recommendations": [
-      "redhat.java"
+      "redhat.java",
+      "vscjava.vscode-java-debug",
+      "vscjava.vscode-java-test"
     ]
 }


### PR DESCRIPTION
Signed-off-by: Vitaliy Gulyy <vgulyy@redhat.com>

Adds missing `vscjava.vscode-java-debug` and `vscjava.vscode-java-test` extensions.

Solves https://github.com/eclipse/che/issues/21644