### PR TITLE
chore(devfile) use ubi-latest tag for UDI

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -4,7 +4,7 @@ metadata:
 components:
   - name: tools
     container:
-      image: quay.io/devfile/universal-developer-image:ubi8-0e189d9
+      image: quay.io/devfile/universal-developer-image:ubi8-latest
       memoryLimit: 3Gi
       endpoints:
         - exposure: none


### PR DESCRIPTION
chore(devfile) use ubi-latest tag for UDI

Related issue: https://github.com/eclipse/che/issues/21979

![Screenshot from 2023-03-21 15-08-45](https://user-images.githubusercontent.com/1271546/226615644-f8b73931-edd2-48fa-8a55-4e168c0be0b6.png)
