### PR TITLE
devfile: set schemaVersion 2.2.2

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -1,4 +1,4 @@
-schemaVersion: 2.1.0
+schemaVersion: 2.2.2
 metadata:
   name: java-lombok
 components:


### PR DESCRIPTION
Set devfile schemaVersion: 2.2.2

![screenshot-che-dogfooding apps che-dev x6e0 p1 openshiftapps com-2024 01 31-15_38_21](https://github.com/che-samples/lombok-project-sample/assets/1271546/243bbe30-2825-4c5d-9113-e1ba4fe939a5)

Related issue: https://github.com/eclipse/che/issues/21985

